### PR TITLE
Various cosmetic changes to make `clippy` happy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ fn normalise_dates(
     }
 
     // check that the date is not in the future - otherwise set it to now
-    if now.timestamp() < end_date.timestamp() {
+    if now.and_utc().timestamp() < end_date.and_utc().timestamp() {
         end_date = now;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,8 @@ pub async fn get_intensity_region(regionid: u8) -> Result<i32, ApiError> {
 }
 
 fn parse(date: &str) -> Result<NaiveDateTime, chrono::ParseError> {
-    let sd = NaiveDate::parse_from_str(date, "%Y-%m-%d");
-    if sd.is_ok() {
-        return Ok(sd.unwrap().and_hms_opt(0, 0, 0).unwrap());
+    if let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d") {
+        return Ok(date.and_hms_opt(0, 0, 0).unwrap());
     }
     // try the longest form or fail
     NaiveDateTime::parse_from_str(date, "%Y-%m-%dT%H:%MZ")
@@ -276,9 +275,8 @@ pub async fn get_intensities(url: &str) -> Result<RegionData, ApiError> {
 
     if status.is_success() {
         let json_str = response.text().await?;
-        let structure: Result<PowerData, serde_json::Error> = serde_json::from_str(&json_str);
-        if structure.is_ok() {
-            Ok(structure.unwrap().data)
+        if let Ok(PowerData { data }) = serde_json::from_str::<PowerData>(&json_str) {
+            Ok(data)
         } else {
             Err(ApiError::Error(format!("Invalid JSON returned {json_str}")))
         }
@@ -313,9 +311,8 @@ async fn get_instant_data(url: &str) -> Result<Root, ApiError> {
     let status = response.status();
 
     if status.is_success() {
-        let structure = response.json::<Root>().await;
-        if structure.is_ok() {
-            return Ok(structure.unwrap());
+        if let Ok(root) = response.json::<Root>().await {
+            return Ok(root);
         } else {
             return Err(ApiError::Error("Invalid JSON returned".to_string()));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,6 @@ pub async fn get_intensities(url: &str) -> Result<RegionData, ApiError> {
 }
 
 /// Retrieves the intensity value from a structure
-///
 async fn get_intensity(url: &str) -> Result<i32, ApiError> {
     let result = get_instant_data(url).await.map_err(|err| err)?;
 
@@ -307,7 +306,6 @@ async fn get_intensity(url: &str) -> Result<i32, ApiError> {
 }
 
 // Internal method to handle the querying and parsing
-///
 async fn get_instant_data(url: &str) -> Result<Root, ApiError> {
     let client = Client::new();
     let response = client.get(url).send().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ pub async fn get_intensities(url: &str) -> Result<RegionData, ApiError> {
         if structure.is_ok() {
             Ok(structure.unwrap().data)
         } else {
-            return Err(ApiError::Error(format!("Invalid JSON returned {json_str}")));
+            Err(ApiError::Error(format!("Invalid JSON returned {json_str}")))
         }
     } else {
         let body = response.text().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,8 +210,8 @@ pub async fn get_intensities_region(
 
         let url = format!(
             "{BASE_URL}{path}{}/{}/regionid/{regionid}",
-            start_date.format("%Y-%m-%dT%H:%MZ").to_string(),
-            end_date.format("%Y-%m-%dT%H:%MZ").to_string()
+            start_date.format("%Y-%m-%dT%H:%MZ"),
+            end_date.format("%Y-%m-%dT%H:%MZ"),
         );
         let region_data = get_intensities(&url).await?;
         let mut tuples = to_tuple(region_data)?;
@@ -246,8 +246,8 @@ pub async fn get_intensities_postcode(
 
         let url = format!(
             "{BASE_URL}{path}{}/{}/postcode/{postcode}",
-            start_date.format("%Y-%m-%dT%H:%MZ").to_string(),
-            end_date.format("%Y-%m-%dT%H:%MZ").to_string()
+            start_date.format("%Y-%m-%dT%H:%MZ"),
+            end_date.format("%Y-%m-%dT%H:%MZ"),
         );
         let region_data = get_intensities(&url).await?;
         let mut tuples = to_tuple(region_data)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub async fn get_intensity_postcode(postcode: &str) -> Result<i32, ApiError> {
 /// <https://api.carbonintensity.org.uk/regional/regionid/>
 ///
 pub async fn get_intensity_region(regionid: u8) -> Result<i32, ApiError> {
-    if regionid < 1 || regionid > 17 {
+    if !(1..=17).contains(&regionid) {
         return Err(ApiError::Error(
             "Invalid regiondid - should be between 1-17".to_string(),
         ));
@@ -190,7 +190,7 @@ pub async fn get_intensities_region(
     start: &str,
     end: &Option<&str>,
 ) -> Result<Vec<(NaiveDateTime, i32)>, ApiError> {
-    if regionid < 1 || regionid > 17 {
+    if !(1..=17).contains(&regionid) {
         return Err(ApiError::Error(
             "Invalid regiondid - should be between 1-17".to_string(),
         ));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ fn normalise_dates(
     let mut ranges = Vec::new();
 
     let duration = Duration::days(13);
-    let mut current = start_date.clone();
+    let mut current = start_date;
     loop {
         let mut next_end = current + duration;
         // break the end of year boundary
@@ -178,7 +178,7 @@ fn normalise_dates(
             ranges.push((current, next_end));
         }
 
-        current = next_end.clone();
+        current = next_end;
     }
     Ok(ranges)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ pub async fn get_intensities(url: &str) -> Result<RegionData, ApiError> {
 
 /// Retrieves the intensity value from a structure
 async fn get_intensity(url: &str) -> Result<i32, ApiError> {
-    let result = get_instant_data(url).await.map_err(|err| err)?;
+    let result = get_instant_data(url).await?;
 
     let intensity = result
         .data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ pub async fn get_intensities_region(
 
     let path = "regional/intensity/";
 
-    let ranges = normalise_dates(&start, &end)?;
+    let ranges = normalise_dates(start, end)?;
 
     let mut output = Vec::new();
 
@@ -233,7 +233,7 @@ pub async fn get_intensities_postcode(
         return Err(ApiError::Error("Invalid postcode".to_string()));
     }
 
-    let ranges = normalise_dates(&start, &end)?;
+    let ranges = normalise_dates(start, end)?;
 
     let mut output = Vec::new();
     let path = "regional/intensity/";

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,9 +82,9 @@ async fn main() {
 }
 
 fn handle_results(result: Result<Vec<(NaiveDateTime, i32)>, ApiError>) {
-    if result.is_ok() {
-        for t in result.unwrap() {
-            println!("{}, {}", t.0, t.1);
+    if let Ok(results) = result {
+        for (time, value) in results {
+            println!("{}, {}", time, value);
         }
     } else {
         eprintln!("{}", result.unwrap_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,8 @@ struct Args {
 
 enum Target {
     // NATIONAL,
-    POSTCODE,
-    REGION,
+    Postcode,
+    Region,
 }
 
 impl FromStr for Target {
@@ -36,8 +36,8 @@ impl FromStr for Target {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             //"" => Ok(Target::NATIONAL),
-            _ if s.parse::<u8>().is_ok() => Ok(Target::REGION),
-            _ => Ok(Target::POSTCODE),
+            _ if s.parse::<u8>().is_ok() => Ok(Target::Region),
+            _ => Ok(Target::Postcode),
         }
     }
 }
@@ -54,12 +54,12 @@ async fn main() {
         let end_date: Option<&str> = args.end_date.as_deref();
 
         match target {
-            Target::POSTCODE => {
+            Target::Postcode => {
                 let result =
                     get_intensities_postcode(args.value.as_str(), start_date, &end_date).await;
                 handle_results(result);
             }
-            Target::REGION => {
+            Target::Region => {
                 let id: u8 = args.value.parse::<u8>().unwrap();
                 let result = get_intensities_region(id, start_date, &end_date).await;
                 handle_results(result);
@@ -67,12 +67,12 @@ async fn main() {
         }
     } else {
         match target {
-            Target::POSTCODE => {
+            Target::Postcode => {
                 let postcode = args.value.as_str();
                 let result = get_intensity_postcode(postcode).await;
                 handle_result(result, "postcode", postcode);
             }
-            Target::REGION => {
+            Target::Region => {
                 let id: u8 = args.value.parse::<u8>().unwrap();
                 let result = get_intensity_region(id).await;
                 handle_result(result, "region", id.to_string().as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ async fn main() {
 
     // look for a range if a date was specified
     if let Some(start_date) = &args.start_date {
-        let end_date: Option<&str> = args.end_date.as_ref().map(|r| &**r);
+        let end_date: Option<&str> = args.end_date.as_deref();
 
         match target {
             Target::POSTCODE => {


### PR DESCRIPTION
Hopefully the commits are small enough to be easy to understand but this is solving the complains from `cargo clippy`.
Things like:
- unneded returns
- unnecessary `.to_string()` calls when formatting
- unnecessary `.clone()` on `Copy` values
- use `if let`/destructuring instead of using `if is_ok()` and then `unwrap()`
- etc...

Plus:
- removed deprecated `timestamp()` use