### PR TITLE
Simplified public interface and removed duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,15 @@ You can use the library in your Rust project by adding it to cargo with
 then declaring it in your code 
 
 ```Rust
-use carbonintensity::{
-    get_intensities_postcode, get_intensities_region, get_intensity_postcode, get_intensity_region,
-    ApiError,
-};
+use carbonintensity::{get_intensity, Target, Region};
 
 ...
 
-  let result = get_intensity_postcode(postcode).await;
+  let scotland = Region::Scotland;
+  let result = get_intensity(&Target::Region(scotland)).await;
 
 ```
 
 ## License
 
 This project is provided under [Apache License](http://www.apache.org/licenses/LICENSE-2.0).
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,10 @@ use thiserror::Error;
 use url::ParseError;
 
 mod region;
+mod target;
 
 pub use region::Region;
+pub use target::Target;
 
 /// An error communicating with the Carbon Intensity API.
 #[derive(Debug, Error)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 use std::process;
 
-use carbonintensity::{
-    get_intensities_postcode, get_intensities_region, get_intensity_postcode, get_intensity_region,
-    ApiError, Region,
-};
+use carbonintensity::{get_intensities, get_intensity, ApiError, Target};
 use chrono::NaiveDateTime;
 use clap::Parser;
 
@@ -35,27 +32,11 @@ async fn main() {
     if let Some(start_date) = &args.start_date {
         let end_date: Option<&str> = args.end_date.as_deref();
 
-        match target {
-            Target::Postcode(postcode) => {
-                let result = get_intensities_postcode(&postcode, start_date, &end_date).await;
-                handle_results(result);
-            }
-            Target::Region(region) => {
-                let result = get_intensities_region(region, start_date, &end_date).await;
-                handle_results(result);
-            }
-        }
+        let result = get_intensities(&target, start_date, &end_date).await;
+        handle_results(result);
     } else {
-        match target {
-            Target::Postcode(postcode) => {
-                let result = get_intensity_postcode(&postcode).await;
-                handle_result(result, &"postcode", &postcode);
-            }
-            Target::Region(region) => {
-                let result = get_intensity_region(region).await;
-                handle_result(result, &"region", &region);
-            }
-        }
+        let result = get_intensity(&target).await;
+        handle_result(result, &target);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, process, str::FromStr};
+use std::process;
 
 use carbonintensity::{
     get_intensities_postcode, get_intensities_region, get_intensity_postcode, get_intensity_region,
@@ -22,28 +22,6 @@ struct Args {
     #[clap()]
     /// numerical value for a region (1-17) or first part of a UK postcode
     pub value: String,
-}
-
-enum Target {
-    // NATIONAL,
-    Postcode(String),
-    Region(Region),
-}
-
-impl FromStr for Target {
-    type Err = ();
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        //"" => Ok(Target::NATIONAL)
-
-        // Check if input can be parsed as a Region
-        if let Ok(region) = s.parse::<Region>() {
-            return Ok(Target::Region(region));
-        }
-
-        // Assumes the string was a postcode
-        Ok(Target::Postcode(s.to_string()))
-    }
 }
 
 #[tokio::main]
@@ -92,14 +70,9 @@ fn handle_results(result: Result<Vec<(NaiveDateTime, i32)>, ApiError>) {
     }
 }
 
-fn handle_result(result: Result<i32, ApiError>, method: &dyn Display, value: &dyn Display) {
+fn handle_result(result: Result<i32, ApiError>, target: &Target) {
     if result.is_ok() {
-        println!(
-            "Carbon intensity for {} {}: {:?}",
-            method,
-            value,
-            result.unwrap()
-        );
+        println!("Carbon intensity for {}: {:?}", target, result.unwrap());
     } else {
         eprintln!("{}", result.unwrap_err());
         process::exit(1);

--- a/src/target.rs
+++ b/src/target.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use crate::Region;
 
+/// Carbon intensity target, e.g. a postcode or a region
 pub enum Target {
     // NATIONAL,
     Postcode(String),

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,0 +1,36 @@
+use std::str::FromStr;
+
+use crate::Region;
+
+pub enum Target {
+    // NATIONAL,
+    Postcode(String),
+    Region(Region),
+}
+
+impl FromStr for Target {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        //"" => Ok(Target::NATIONAL)
+
+        // Check if input can be parsed as a Region
+        if let Ok(region) = s.parse::<Region>() {
+            return Ok(Target::Region(region));
+        }
+
+        // Assumes the string was a postcode
+        Ok(Target::Postcode(s.to_string()))
+    }
+}
+
+impl std::fmt::Display for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let target = match self {
+            Target::Postcode(postcode) => format!("postcode {postcode}"),
+            Target::Region(region) => region.to_string(),
+        };
+
+        write!(f, "{target}")
+    }
+}


### PR DESCRIPTION
Simplified crate public API and avoided duplication.

There are now only 2 public functions:
- `get_intensity()` gets a `Target`
- `get_intensities()` gets a `Target` and a date range

Examples:
```Rust
let scotland = Region::Scotland;
let result = get_intensity(&Target::Region(scotland)).await;

let sw1 = Target::Postcode("SW1".to_string());
let result = get_intensity(&sw1);

let results = get_intensities(&sw1, "2024-10-01", &None).await;
```

**NOTE**: These are breaking changes:
- `get_intenties_postcode()`/`get_intenties_region()` are gone, replaced
  by a single `get_intenties()` function which takes a `Target`
- previously public function `get_intenties()` (the one getting intensities
  by URL) have been "removed"/renamed to `get_intenties_for_url()`.
  This is now private. I'm assuming it was meant to be an internal utility
  function (the similar `get_intensity()` function is private).
- similarly `get_intenty_postcode()`/`get_intenty_region()` are gone, replaced
  by a single `get_intensity()` function which takes a `Target`

I've updated the README example.

As a result the cli logic is simpler as it doesn't have to match the target
and call different functions based on whether we are querying for a region
or a postcode.