### PR TITLE
Make requests concurrently

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub enum ApiError {
 
 pub type Result<T> = std::result::Result<T, ApiError>;
 
+pub type IntensityForDate = (NaiveDateTime, i32);
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GenerationMix {
     fuel: String,
@@ -200,8 +202,8 @@ pub async fn get_intensities(
 
 /// converts the values from JSON into a simpler
 /// representation Vec<DateTime, float>
-fn to_tuples(data: RegionData) -> Result<Vec<(NaiveDateTime, i32)>> {
-    let mut values: Vec<(NaiveDateTime, i32)> = Vec::new();
+fn to_tuples(data: RegionData) -> Result<Vec<IntensityForDate>> {
+    let mut values: Vec<IntensityForDate> = Vec::new();
     for d in data.data {
         let start_date = parse_date(&d.from)?;
         let intensity = d.intensity.forecast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub async fn get_intensity(target: &Target) -> Result<i32, ApiError> {
     get_intensity_for_url(&url).await
 }
 
-fn parse(date: &str) -> Result<NaiveDateTime, chrono::ParseError> {
+fn parse_date(date: &str) -> Result<NaiveDateTime, chrono::ParseError> {
     if let Ok(date) = NaiveDate::parse_from_str(date, "%Y-%m-%d") {
         return Ok(date.and_hms_opt(0, 0, 0).unwrap());
     }
@@ -110,7 +110,7 @@ fn normalise_dates(
     start: &str,
     end: &Option<&str>,
 ) -> Result<Vec<(NaiveDateTime, NaiveDateTime)>, ApiError> {
-    let start_date = parse(start)?;
+    let start_date = parse_date(start)?;
 
     let now = Local::now().naive_local();
 
@@ -118,7 +118,7 @@ fn normalise_dates(
     let end_date = match end {
         None => now,
         Some(end_date) => {
-            let end_date = parse(end_date)?;
+            let end_date = parse_date(end_date)?;
             // check that the date is not in the future - otherwise set it to now
             if now.and_utc().timestamp() < end_date.and_utc().timestamp() {
                 now
@@ -204,7 +204,7 @@ pub async fn get_intensities(
 fn to_tuple(data: RegionData) -> Result<Vec<(NaiveDateTime, i32)>, ApiError> {
     let mut values: Vec<(NaiveDateTime, i32)> = Vec::new();
     for d in data.data {
-        let start_date = parse(&d.from)?;
+        let start_date = parse_date(&d.from)?;
         let intensity = d.intensity.forecast;
         values.push((start_date, intensity));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,11 +151,9 @@ fn normalise_dates(
         if next_end >= new_year {
             next_end = new_year;
         }
+        ranges.push((current, end_date));
         if next_end >= end_date {
-            ranges.push((current, end_date));
             break;
-        } else {
-            ranges.push((current, next_end));
         }
 
         current = next_end;


### PR DESCRIPTION
This is related to Issue #7.

Spawn a Tokio task per request instead of making them sequentially.
Details about how the data flows back from the green threads into the format we wants are given in the [commit message here](https://github.com/jnioche/carbonintensity-api/commit/403d1bf6b788f231598c83051157b7a475cd3ae0) - hopefully makes sense.

As mentioned in that commit message I may experiment with the result unwrapping further to see if I can get to something even simpler/more readable (you should have seen the original version of this 😅) 

I've made some tweaks/refactorings. Explaination is given in the individual commit messages.
If you really prefer I can split the refactorings commits into its own PR and then have a PR only for the concurrent change.