### PR TITLE
Add some tests for the date handling logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,9 +254,9 @@ async fn get_instant_data(url: &str) -> Result<Root> {
 
 /// Makes a GET request to the given URL
 ///
-/// Deserialize the JSON response as `T` and returns Ok<T> if all is well.
+/// Deserialise the JSON response as `T` and returns Ok<T> if all is well.
 /// Returns an `ApiError` when the HTTP request failed or the response body
-/// couldn't be deserialized as a `T` value.
+/// couldn't be deserialised as a `T` value.
 async fn get_response<T>(url: &str) -> Result<T>
 where
     T: DeserializeOwned,
@@ -342,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_power_data_test() {
+    fn deserialise_power_data_test() {
         let json_str = r#"
         {"data":{"regionid":11,"shortname":"South West England","postcode":"BS7","data":[{"from":"2022-12-31T23:30Z","to":"2023-01-01T00:00Z","intensity":{"forecast":152,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.4},{"fuel":"coal","perc":3.3},{"fuel":"imports","perc":14.3},{"fuel":"gas","perc":28.5},{"fuel":"nuclear","perc":7},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.5},{"fuel":"solar","perc":0},{"fuel":"wind","perc":45.1}]},{"from":"2023-01-01T00:00Z","to":"2023-01-01T00:30Z","intensity":{"forecast":181,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.4},{"fuel":"coal","perc":3.4},{"fuel":"imports","perc":9.1},{"fuel":"gas","perc":36.1},{"fuel":"nuclear","perc":6.8},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":42.8}]},{"from":"2023-01-01T00:30Z","to":"2023-01-01T01:00Z","intensity":{"forecast":189,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.3},{"fuel":"coal","perc":3.4},{"fuel":"imports","perc":12.1},{"fuel":"gas","perc":37.6},{"fuel":"nuclear","perc":6.4},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":38.8}]},{"from":"2023-01-01T01:00Z","to":"2023-01-01T01:30Z","intensity":{"forecast":183,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.7},{"fuel":"coal","perc":3.2},{"fuel":"imports","perc":6.1},{"fuel":"gas","perc":37.3},{"fuel":"nuclear","perc":7.3},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":44}]},{"from":"2023-01-01T01:30Z","to":"2023-01-01T02:00Z","intensity":{"forecast":175,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.5},{"fuel":"coal","perc":2.9},{"fuel":"imports","perc":6.6},{"fuel":"gas","perc":36},{"fuel":"nuclear","perc":7.2},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":45.5}]}]}}
     "#;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,14 +346,13 @@ mod tests {
     }
 
     #[test]
-    fn it_works() {
+    fn deserialize_power_data_test() {
         let json_str = r#"
         {"data":{"regionid":11,"shortname":"South West England","postcode":"BS7","data":[{"from":"2022-12-31T23:30Z","to":"2023-01-01T00:00Z","intensity":{"forecast":152,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.4},{"fuel":"coal","perc":3.3},{"fuel":"imports","perc":14.3},{"fuel":"gas","perc":28.5},{"fuel":"nuclear","perc":7},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.5},{"fuel":"solar","perc":0},{"fuel":"wind","perc":45.1}]},{"from":"2023-01-01T00:00Z","to":"2023-01-01T00:30Z","intensity":{"forecast":181,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.4},{"fuel":"coal","perc":3.4},{"fuel":"imports","perc":9.1},{"fuel":"gas","perc":36.1},{"fuel":"nuclear","perc":6.8},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":42.8}]},{"from":"2023-01-01T00:30Z","to":"2023-01-01T01:00Z","intensity":{"forecast":189,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.3},{"fuel":"coal","perc":3.4},{"fuel":"imports","perc":12.1},{"fuel":"gas","perc":37.6},{"fuel":"nuclear","perc":6.4},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":38.8}]},{"from":"2023-01-01T01:00Z","to":"2023-01-01T01:30Z","intensity":{"forecast":183,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.7},{"fuel":"coal","perc":3.2},{"fuel":"imports","perc":6.1},{"fuel":"gas","perc":37.3},{"fuel":"nuclear","perc":7.3},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":44}]},{"from":"2023-01-01T01:30Z","to":"2023-01-01T02:00Z","intensity":{"forecast":175,"index":"moderate"},"generationmix":[{"fuel":"biomass","perc":1.5},{"fuel":"coal","perc":2.9},{"fuel":"imports","perc":6.6},{"fuel":"gas","perc":36},{"fuel":"nuclear","perc":7.2},{"fuel":"other","perc":0},{"fuel":"hydro","perc":0.4},{"fuel":"solar","perc":0},{"fuel":"wind","perc":45.5}]}]}}
     "#;
 
-        let result: std::result::Result<PowerData, serde_json::Error> =
+        let _result: std::result::Result<PowerData, serde_json::Error> =
             serde_json::from_str(json_str);
-        println!("{:?}", result);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,8 +352,24 @@ mod tests {
     }
 
     #[test]
-    fn range_splitting() {
-        let periods = normalise_dates("2022-12-01", &Option::Some("2023-02-01"));
-        println!("{:?}", periods);
+    fn normalise_dates_test() {
+        // Invalid start date
+        let result = normalise_dates("not a date", &None);
+        assert!(matches!(result, Err(ApiError::DateParseError(_))));
+
+        // Invalid end date
+        let result = normalise_dates("2024-01-01", &Some("not a date"));
+        assert!(matches!(result, Err(ApiError::DateParseError(_))));
+
+        // Ranges splitting logic
+        let result = normalise_dates("2022-12-01", &Some("2023-01-01"));
+        assert!(result.is_ok());
+        let ranges = result.unwrap();
+        let expected = vec![
+            (test_date_time("2022-12-01"), test_date_time("2022-12-14")),
+            (test_date_time("2022-12-14"), test_date_time("2022-12-27")),
+            (test_date_time("2022-12-27"), test_date_time("2023-01-01")),
+        ];
+        assert_eq!(ranges, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,11 +324,7 @@ mod tests {
             Data::test_data("2024-03-01", "2024-04-01", 250),
         ];
         let result = to_tuples(data);
-        assert!(result.is_err());
-        match result.err().unwrap() {
-            ApiError::DateParseError(_err) => {} // success,
-            err => panic!("Expected a ApiError::DateParseError, got {:?}", err),
-        };
+        assert!(matches!(result, Err(ApiError::DateParseError(_))));
 
         // Happy path
         let data = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,13 +216,14 @@ pub async fn get_intensities(
 /// converts the values from JSON into a simpler
 /// representation Vec<DateTime, float>
 fn to_tuples(data: RegionData) -> Result<Vec<IntensityForDate>> {
-    let mut values: Vec<IntensityForDate> = Vec::new();
-    for d in data.data {
-        let start_date = parse_date(&d.from)?;
-        let intensity = d.intensity.forecast;
-        values.push((start_date, intensity));
-    }
-    Ok(values)
+    data.data
+        .into_iter()
+        .map(|datum| {
+            let start_date = parse_date(&datum.from)?;
+            let intensity = datum.intensity.forecast;
+            Ok((start_date, intensity))
+        })
+        .collect()
 }
 
 async fn get_intensities_for_url(url: &str) -> Result<RegionData> {


### PR DESCRIPTION
Added some tests for the internal utility functions used to handle dates:
- `to_tuples()`
- `normalise_dates()`

These would have prevented [this glitch](https://github.com/jnioche/carbonintensity-api/pull/13#issuecomment-2395047308) earlier :)

I've also made some small refactoring after introducing these tests:
 - `to_tuples()` just takes the `Vec<Data>` instead of the whole `RegionData` struct (as it's only using the data anyway)
   - this also simplify the test, see current version vs. [original iteration](https://github.com/jnioche/carbonintensity-api/commit/aee436a2fdcd160eaf23bb68836fcf5d54e6f655) where the test had to construct a `RegionData` even tho the logic only involves the data
 - `to_tuples()` uses Rust's Iterators and avoids `mut`/`Vec::push()`


This should resolve Issue #14 