### PR TITLE
Prevent start date to be before first data available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "carbonintensity-api"
 version = "0.3.0"
 edition = "2021"
+rust-version = "1.80"
 authors = ["Julien Nioche <jnioche@gmail.com>"]
 description = "Provides a client for the UK National Grid Carbon Intensity API"
 repository = "https://github.com/jnioche/carbonintensity-api"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,16 +123,11 @@ fn normalise_dates(start: &str, end: &Option<&str>) -> Result<Vec<(NaiveDateTime
     // if the end is not set - use now
     let end_date = match end {
         None => now,
-        Some(end_date) => {
-            let end_date = parse_date(end_date)?;
-            // check that the date is not in the future - otherwise set it to now
-            if now.and_utc().timestamp() < end_date.and_utc().timestamp() {
-                now
-            } else {
-                end_date
-            }
-        }
+        Some(end_date) => parse_date(end_date)?,
     };
+
+    let start_date = validate_date(start_date)?;
+    let end_date = validate_date(end_date)?;
 
     //  split into ranges
     let mut ranges = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ mod tests {
     }
 
     #[test]
-    fn normalise_dates_test() {
+    fn normalise_dates_invalid() {
         // Invalid start date
         let result = normalise_dates("not a date", &None);
         assert!(matches!(result, Err(ApiError::DateParseError(_))));
@@ -393,7 +393,10 @@ mod tests {
         // Invalid end date
         let result = normalise_dates("2024-01-01", &Some("not a date"));
         assert!(matches!(result, Err(ApiError::DateParseError(_))));
+    }
 
+    #[test]
+    fn normalise_dates_splitting() {
         // Ranges splitting logic
         let result = normalise_dates("2022-12-01", &Some("2023-01-01"));
         assert!(result.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,10 @@ mod tests {
         // Invalid end date
         let result = normalise_dates("2024-01-01", &Some("not a date"));
         assert!(matches!(result, Err(ApiError::DateParseError(_))));
+
+        // Start date too old
+        let result = normalise_dates("2001-01-01", &None);
+        assert!(matches!(result, Err(ApiError::DateTooOld)));
     }
 
     #[test]


### PR DESCRIPTION
Check that dates are not before the oldest valid date (`2018-05-10 23:30:00`, [see issue comment](https://github.com/jnioche/carbonintensity-api/issues/15#issuecomment-2395109583))

See related Issue #15 

```sh
$ cargo run -- -s 1984-08-04 bs7

Dates must be after 2018-05-10
```

**NOTE**: To avoid re-creating a new `NaiveDateTime` each time the validation utility function is invoked the constant is initialised lazily using [`LazyLock`(https://doc.rust-lang.org/stable/std/sync/struct.LazyLock.html). However this was stabilised in [Rust 1.80](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html).
This effectively means we're pushing the MSRV (minimum supported Rust version) ahead (6 releases). I think this is still better than the alternatives and the crate needs 1.74+ anyway at the moment. More information in these 2 commit messages: [one](https://github.com/jnioche/carbonintensity-api/pull/20/commits/b00f50aaed18161074872c6340cfb11073b34a92), [two](https://github.com/jnioche/carbonintensity-api/pull/20/commits/e0a3e23fc6f973b16ed282f47af6f7254080734d).