### PR TITLE
Run clippy in CI, fail if there are warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Run clippy
+      run: cargo clippy -- -Dwarnings
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@ use reqwest::{Client, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 
-// TODO: Testing clippy in CI - remove
-const UNUSED: u8 = 42;
-
 mod region;
 mod target;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ use reqwest::{Client, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 
+// TODO: Testing clippy in CI - remove
+const UNUSED: u8 = 42;
+
 mod region;
 mod target;
 


### PR DESCRIPTION
This is useful to avoid committing code of subpar quality or potentially
wrong.

[Example of failed run](https://github.com/jnioche/carbonintensity-api/actions/runs/11202121339/job/31137855289?pr=22):

```
cargo clippy -- -Dwarnings
[...]
Checking carbonintensity-api v0.3.0 (/home/runner/work/carbonintensity-api/carbonintensity-api)
error: constant `UNUSED` is never used
  --> src/lib.rs:11:7
   |
11 | const UNUSED: u8 = 42;
   |       ^^^^^^
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`
error: could not compile `carbonintensity-api` (lib) due to 1 previous error
Error: Process completed with exit code 101.
```