### PR TITLE
Print requests when running in debug profile

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,8 @@ where
     T: DeserializeOwned,
 {
     let client = Client::new();
+    #[cfg(debug_assertions)]
+    eprintln!("GET {url}");
     let response = client.get(url).send().await?;
 
     let status = response.status();


### PR DESCRIPTION
When running a debug build print which requests are going out. This is useful for debugging.

As this is a `cfg` expression the `eprintln!()` would not be there in a a release build at all.

Example:

```sh
$ cargo run -- -s 2024-09-01 -e 2024-09-20 13
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running `/Users/xoen/.cargo/target/debug/carbonintensity-api -s 2024-09-01 -e 2024-09-20 13`
GET https://api.carbonintensity.org.uk/regional/intensity/2024-09-01T00:01Z/2024-09-14T00:01Z/regionid/13
GET https://api.carbonintensity.org.uk/regional/intensity/2024-09-14T00:01Z/2024-09-20T00:01Z/regionid/13
2024-09-01 00:00:00, 39
2024-09-01 00:30:00, 58
[...]

$ cargo run --release -- -s 2024-09-01 -e 2024-09-20 13
   Compiling carbonintensity-api v0.3.0 (/Users/xoen/Projects/Personal/Rust/carbonintensity-api)
    Finished `release` profile [optimized] target(s) in 1.82s
     Running `/Users/xoen/.cargo/target/release/carbonintensity-api -s 2024-09-01 -e 2024-09-20 13`
2024-09-01 00:00:00, 39
2024-09-01 00:30:00, 58
[...]
```

I don't know if this is controversial, but I think it's very useful when tweaking things.