### PR TITLE
Document API weirdness with regards to multi-years ranges

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,19 @@ mod tests {
     }
 
     #[test]
+    fn normalise_dates_skipping_year() {
+        // Ranges spanning 2 year. See: https://github.com/jnioche/carbonintensity-api/issues/6
+        let result = normalise_dates("2022-12-31", &Some("2023-01-02"));
+        assert!(result.is_ok());
+        let ranges = result.unwrap();
+        let expected = vec![
+            (test_date_time("2022-12-31"), test_date_time("2023-01-01")),
+            (test_date_time("2023-01-01"), test_date_time("2023-01-02")),
+        ];
+        assert_eq!(ranges, expected);
+    }
+
+    #[test]
     fn validate_date_test() {
         // valid dates just returned as-is
         let just_a_day = test_date_time("2024-07-30");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,6 +451,9 @@ mod tests {
     #[test]
     fn normalise_dates_skipping_year() {
         // Ranges spanning 2 year. See: https://github.com/jnioche/carbonintensity-api/issues/6
+        // The API doesn't cope well with ranges spanning more than one year.
+        // If end_date is in a different year the API would use year end as
+        // end_date and don't return any values beyond that datetime.
         let result = normalise_dates("2022-12-31", &Some("2023-01-02"));
         assert!(result.is_ok());
         let ranges = result.unwrap();


### PR DESCRIPTION
I added an explicit test with a bit more context to explain why the `normalise_ranges()` is checking for the end of the year (or at least my understanding of it).

### The problem
Example:

```sh
$ curl "https://api.carbonintensity.org.uk/regional/intensity/2022-12-31T00:01Z/2023-01-01T05:00Z/regionid/13" | jq '.data.data[].from'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17235  100 17235    0     0  71119      0 --:--:-- --:--:-- --:--:-- 71219
"2022-12-31T00:00Z"
"2022-12-31T00:30Z"
[...]
"2022-12-31T22:30Z"
"2022-12-31T23:00Z"
```

What happened to the values for the 1st January?

This is why currently the logic checks if a range is spanning multiple
years, e.g. 2023-12-30..2024-01-10, and it splits it into 2 ranges,
e.g. 2023-12-30..2024-01-01 and 2024-01-01..2024-01-10.