### PR TITLE
Check incompatible changes with `cargo-semver-checks`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check SemVer
+      uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
[`cargo-semver-checks`] can detect if any change which is backward-incompatible is introduced.

It works by comparing current version in `Cargo.toml` (unpublished `0.3.0` in our case) against the latest published version (`0.2.0` in this case) and checking against a bunch of rules if the new changes are compatible or whether we need to bump the version.

In this case as the `Cargo.toml` was already changed from `0.2.0` => `0.3.0` the checks don't fail, but if we didn't bump the version it would have failed because of the various breaking changes we've made.

It is useful to have CI run this as sometimes changes can be backward-incompatible in surprising ways.

[`cargo-semver-checks`]: https://github.com/obi1kenobi/cargo-semver-checks